### PR TITLE
Logging levels and CLI flag

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -10,10 +10,10 @@ simple_logger = "4.2.0"
 clap = { version = "4.3.15", features = ["derive"] }
 regex = "1.9.5"
 cubelib = { path = "../cubelib", features = ["serde_support", "fs"]}
+serde = { version = "^1.0.188", features = ["derive"] }
 
 [dev-dependencies]
 csv = "1.3.0"
-serde = { version = "^1.0.188" }
 
 [features]
 default = ["finish"]

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -1,23 +1,21 @@
 use std::collections::HashMap;
 use std::str::FromStr;
-use clap::Parser;
+use clap::{Parser, ValueEnum};
 use regex::Regex;
 use cubelib::defs::*;
 use cubelib::steps::step::{StepConfig};
+use serde::Deserialize;
+use log::LevelFilter;
 
 #[derive(Parser)]
 #[command(name = "Cubelib")]
 #[command(author = "Jonas Balsfulland <cubelib@joba.me>")]
 #[command(version = "1.2")]
 pub struct Cli {
-    #[arg(short, long, default_value_t = false, group = "log_level", help = "Enables more detailed logging")]
-    pub verbose: bool,
-    #[arg(long, default_value_t = false, group = "log_level", help = "Prints nothing but the solutions")]
-    pub quiet: bool,
-    #[arg(id = "compact", short = 'c', long = "compact", default_value_t = false, help = "Prints only the solution, and not the different steps")]
-    pub compact_solutions: bool,
-    #[arg(short = 'p', long = "plain", default_value_t = false, requires = "compact", help = "Does not print the number of moves of the solution")]
-    pub plain_solution: bool,
+    #[arg(short, long = "log", help = "Log level")]
+    pub log: LogLevel,
+    #[arg(short, long = "format", help="Solution output format")]
+    pub format: SolutionFormat,
     #[arg(short = 'a', long = "all", default_value_t = false, help = "Print solutions that would otherwise get filtered out. E.g. an EO ending in F'")]
     pub all_solutions: bool,
     #[arg(short = 'm', long = "min", default_value_t = 0, help = "Minimum length of solutions")]
@@ -34,6 +32,40 @@ pub struct Cli {
     pub steps: String,
     pub scramble: String,
 }
+
+#[derive(ValueEnum, Clone, Default, Debug, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum LogLevel {
+    Error, // Unrecoverable error. Results cannot be trusted
+    #[default]
+    Warn, // Unexpected input, user-correctable
+    Info, // User-meaningful message
+    Debug, // Developer-meaningful message
+    Trace // DFS step
+}
+
+impl LogLevel {
+    pub fn to_level_filter(&self) -> LevelFilter {
+        match self {
+            LogLevel::Error => LevelFilter::Error,
+            LogLevel::Warn => LevelFilter::Warn,
+            LogLevel::Info => LevelFilter::Info,
+            LogLevel::Debug => LevelFilter::Debug,
+            LogLevel::Trace => LevelFilter::Trace,
+        }
+    }
+}
+
+#[derive(ValueEnum, Clone, Default, Debug, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SolutionFormat {
+    #[default]
+    Detailed,
+    Compact,
+    Plain
+}
+
+
 
 impl Cli {
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -11,27 +11,20 @@ use cubelib::solver::df_search::CancelToken;
 use cubelib::solver::solution::Solution;
 use cubelib::steps::{eo, solver};
 use cubelib::steps::tables::PruningTables333;
-use log::{debug, error, info, LevelFilter};
+use log::{error, info};
 use simple_logger::SimpleLogger;
 use cubelib::cube::turn::ApplyAlgorithm;
 
-use crate::cli::Cli;
+use crate::cli::{Cli, SolutionFormat};
 
 mod cli;
 
 fn main() {
     let cli: Cli = Cli::parse();
     SimpleLogger::new()
-        .with_level(if cli.verbose {
-            LevelFilter::Trace
-        } else if cli.quiet {
-            LevelFilter::Error
-        } else {
-            LevelFilter::Info
-        })
+        .with_level(cli.log.to_level_filter())
         .init()
         .unwrap();
-
 
     let scramble = Algorithm::from_str(cli.scramble.as_str()).expect("Invalid scramble {}");
     let mut cube = Cube333::default();
@@ -89,17 +82,17 @@ fn main() {
 
     //The iterator is always sorted, so this just prints the shortest solutions
     for solution in solutions {
-        if cli.compact_solutions {
-            if cli.plain_solution {
-                println!("{}", Into::<Algorithm>::into(solution));
-            } else {
+        match cli.format {
+            SolutionFormat::Plain =>
+                println!("{}", Into::<Algorithm>::into(solution)),
+            SolutionFormat::Compact => {
                 let alg = Into::<Algorithm>::into(solution);
                 println!("{alg} ({})", alg.len());
-            }
-        } else {
-            println!("{}", solution);
+            },
+            SolutionFormat::Detailed =>
+                println!("{}", solution)
         }
     }
 
-    debug!("Took {}ms", time.elapsed().as_millis());
+    info!("Took {}ms", time.elapsed().as_millis());
 }

--- a/cubelib/src/solver/solution.rs
+++ b/cubelib/src/solver/solution.rs
@@ -138,7 +138,7 @@ impl Display for Solution {
                 format!("{}{comment}", step.kind.to_string())
             };
             total_moves += alg_length;
-            writeln!(f, "{:longest_alg_length$}  //{name:longest_name_length$} ({alg_length}/{total_moves})", step.alg.to_string())?;
+            writeln!(f, "{:longest_alg_length$}  // {name:longest_name_length$} ({alg_length}/{total_moves})", step.alg.to_string())?;
         }
         let final_alg: Algorithm = if self.steps.last().map(|x| x.kind == StepKind::FIN).unwrap_or(false) {
             Into::<Algorithm>::into(self.clone()).to_uninverted()
@@ -147,7 +147,7 @@ impl Display for Solution {
         };
         writeln!(
             f,
-            "\nSolution ({}): {}",
+            "Solution ({}): {}",
             total_moves,
             final_alg
         )

--- a/cubelib/src/steps/dr/dr_trigger_config.rs
+++ b/cubelib/src/steps/dr/dr_trigger_config.rs
@@ -5,7 +5,7 @@ use std::str::FromStr;
 use std::vec;
 
 use itertools::Itertools;
-use log::{debug, error};
+use log::{debug, warn, error};
 
 use crate::algs::Algorithm;
 use crate::steps::dr::co::COCountUD;
@@ -255,11 +255,11 @@ fn generate_trigger_variations(mut trigger: Algorithm) -> Vec<Vec<Turn333>> {
     }
     if let Some(last) = trigger.normal_moves.last() {
         if !last.face.is_on_axis(CubeAxis::LR) || last.dir == Direction::Half {
-            error!("DRUD triggers should end with R R' L or L'");
+            warn!("Ignoring DRUD triggers that don't end with R R' L or L'");
             return vec![];
         }
     } else {
-        error!("Empty triggers do not make sense");
+        warn!("Ignoring empty triggers");
         return vec![];
     };
     let mut triggers: Vec<Vec<Turn333>> = vec![];

--- a/cubelib/src/steps/htr/subsets.rs
+++ b/cubelib/src/steps/htr/subsets.rs
@@ -2,7 +2,7 @@ use std::cmp::max;
 use std::collections::HashMap;
 use std::str::FromStr;
 use itertools::Itertools;
-use log::{debug, trace, warn};
+use log::{trace, debug, warn};
 use tinyset::Set64;
 use crate::algs::Algorithm;
 use crate::cube::*;
@@ -45,7 +45,7 @@ pub fn dr_subset_filter<'a>(subset_table: &'a HTRSubsetTable, subsets: &Vec<Stri
         .flat_map(|subset_name|{
             let matched_subsets = expand_subset_name(subset_name.as_str());
             if matched_subsets.is_empty() {
-                warn!("Unrecognized subset name {subset_name}, ignoring")
+                warn!("Ignoring unrecognized subset name {subset_name}")
             }
             if matched_subsets.len() == 1 {
                 for (subset, _) in matched_subsets.iter() {
@@ -87,7 +87,7 @@ pub fn gen_subset_tables(htr_table: &mut HTRPruningTable) -> HTRSubsetTable {
     let mut total_checked = 0;
 
     for (subset, id) in DR_SUBSETS.iter().zip(1..) {
-        debug!("Generating NISS table for subset: {id}. {subset:?}");
+        info!("Generating NISS table for subset: {id}. {subset:?}");
         let generator = Algorithm::from_str(subset.generator).unwrap();
         let checked = fill_table(htr_table, &mut subset_table, &generator, id - 1);
         total_checked += checked;

--- a/cubelib/src/steps/solver.rs
+++ b/cubelib/src/steps/solver.rs
@@ -49,7 +49,7 @@ pub fn build_steps(steps: Vec<StepConfig>, tables: &PruningTables333) -> Result<
             (Some(StepKind::EO), StepKind::DR) => {
                 let dr_table = tables.dr().expect("DR table required");
                 if config.params.contains_key("triggers") {
-                    log::info!("Found explicitly defined DR triggers without RZP. Adding RZP step with default settings.");
+                    log::warn!("Found explicitly defined DR triggers without RZP. Adding RZP step with default settings.");
                     let mut rzp_config = StepConfig::new(StepKind::RZP);
                     rzp_config.quality = config.quality;
                     rzp_config.max = config.max;

--- a/cubelib/src/steps/tables.rs
+++ b/cubelib/src/steps/tables.rs
@@ -156,10 +156,10 @@ impl PruningTables333 {
             match res {
                 Ok(v) => {
                     *val = Some(v);
-                    info!("Loaded {key} table from disk");
+                    debug!("Loaded {key} table from disk");
                 },
-                Err(e) => {
-                    error!("Error loading {key} table from disk: {e}");
+                Err(_) => {
+                    info!("{key} table not found on disk");
                 }
             }
         }
@@ -178,10 +178,10 @@ impl PruningTables333 {
             match res {
                 Ok(v) => {
                     *val = Some(v);
-                    info!("Loaded {key} table from disk");
+                    debug!("Loaded {key} table from disk");
                 },
-                Err(e) => {
-                    error!("Error loading {key} table from disk: {e}");
+                Err(_) => {
+                    info!("Error loading {key} table from disk");
                 }
             }
         }
@@ -259,10 +259,10 @@ impl PruningTables333 {
             match HTRSubsetTable::load_from_disk("333", "htr-subset") {
                 Ok(v) => {
                     self.htr_subset = Some(v);
-                    info!("Loaded htr-subset table from disk");
+                    debug!("Loaded htr-subset table from disk");
                 },
-                Err(e) => {
-                    error!("Error loading htr-subset table from disk: {e}");
+                Err(_) => {
+                    info!("htr-subset table not found on disk");
                 }
             }
             if new_table || self.htr_subset.is_none() {


### PR DESCRIPTION
Add a `--log` CLI flag to specify any logging level.

Add comment with guidelines for choosing a log level 

Adjust some logging levels

Replace `--plain` and `--compact` flags with a multi-valued `--format` option 

